### PR TITLE
add missing import of module "sys" when no config file is specified

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import yaml
 import os
+import sys
 
 
 class Config:


### PR DESCRIPTION
Thanks for this neat project @rvojcik .

This pull request fixes a deficiency, where ``gitlab-project-export.py`` exits with a trace (making the error message hard to spot) when no config file is specified.

Thanks for considering.