### PR TITLE
add setup.py, document installation via pip (only) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,21 @@ Primary used for remote backup of projects in GitLab.com to private storage serv
 Code was modified to work with Python3, not longer compatible with Python2.
 
 ## Prerequisite
-* Python Requests library, `sudo pip install requests`
 * Configured Gitlab API Token, https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
 
 ## Install
 
-Simple just clone the project.
+Simply install via pip:
 
-`git clone https://github.com/rvojcik/gitlab-project-export`
+`pip install git+https://github.com/rvojcik/gitlab-project-export`
+
+or clone the project and install dependecies manually:
+
+```
+git clone https://github.com/rvojcik/gitlab-project-export
+pip install pyyaml
+pip install requests
+```
 
 Prepare and edit your config file
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+from os.path import join as path_join, dirname
+from setuptools import setup, find_packages
+
+version = '0.1'
+README = path_join(dirname(__file__), 'README.md')
+long_description = open(README).read()
+setup(
+    name='gitlab-project-export',
+    version=version,
+    description=('Simple python project for exporting gitlab projects '
+                 'with Export Project feature in GitLab API.'),
+    long_description=long_description,
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python',
+    ],
+    author='Robert Vojcik',
+    author_email='robert@vojcik.net',
+    url='https://github.com/rvojcik/gitlab-project-export',
+    download_url='https://github.com/rvojcik/gitlab-project-export/archive/master.tar.gz',
+    packages=(['lib']),
+    install_requires = [
+        'pyyaml',
+        'requests',
+    ],
+    scripts=[
+        'gitlab-project-export.py',
+        'gitlab-project-import.py',
+    ],
+)


### PR DESCRIPTION
This pull request adds a ``setup.py`` file to make installation more convenient.

The README file has been extended with additional installation instructions accordingly.