### PR TITLE
support for time options in backup file name

### DIFF
--- a/config.yaml-example
+++ b/config.yaml-example
@@ -2,7 +2,7 @@
 # Gitlab configuration
 #
 # It is possible to use globbing in project names
-# aka
+# Example:
 #  - group/*
 #  - user/*/documentation
 gitlab:
@@ -10,11 +10,11 @@ gitlab:
     gitlab_url: "https://gitlab.com"
     token: "MY_PERSONAL_SECRET_TOKEN"
     # SSL verify
-    # Correspond to verify option in request doc:
+    # Corresponds to verify option in request doc:
     # https://2.python-requests.org/en/master/api/#requests.Session.merge_environment_settings
     # Can be boolean to control whether we verify the ssl server certificate or string in which case it must be a path to CA bundle
-    # Default is true
-    # If you set it to False, you will get urllib warnings. To supress them set environment variable:
+    # Default is True
+    # If you set it to False, you will get urllib warnings. To supress them, set environment variable:
     # - export PYTHONWARNINGS="ignore:Unverified HTTPS request"
     ssl_verify: True
   projects:
@@ -22,16 +22,16 @@ gitlab:
     - rvojcik/group/*
   # Membership attribute used when searching for projects
   # If you want to export all projects from private gitlab instance
-  # sse False here. In big shared instances or gitlab.com use True
+  # use False here. In big shared instances or gitlab.com, use True
   membership: True
   # Wait Between Exports
   # How many seconds to wait between projects to export.
   # This is due rate-limiting in gitlab.com
   # https://docs.gitlab.com/ee/user/project/settings/import_export.html#rate-limits
   #
-  # If you break the limit API respond with 429 for your IP address for a while.
+  # If you break the limit, API responds with 429 for your IP address for a while.
   #
-  # When you are using this in your private gitlab instance you can set it to 0
+  # When you are using this in your private gitlab instance, you can set it to 0
   wait_between_exports: 303
 
 #
@@ -45,16 +45,19 @@ backup:
   destination: "/data/backup"
 
   # Backup Name template
-  # Is it possible to use some placeholders in the name
+  # It is possible to use some placeholders in the name
   #   {PROJECT_NAME} - Name of the project with full path
-  #   Path slashes is replaces with dashes.
+  #   Path slashes are replaced with dashes.
   #   Example:
   #     rvojcik/project1 => rvojcik-project1
   #
   #   {TIME} - Time of the export
   backup_name: "gitlab-com-{PROJECT_NAME}-{TIME}.tar.gz"
 
-  # Time format tamplate
-  # Time is construct by python strftime.
+  # Time format template
+  # Time is constructed by python strftime.
   # backup_time_format can be anything compatible with strftime
+  #   Blank spaces are replaced with underscores.
+  #   Example:
+  #     %Y%m%d %H%M => %Y%m%d_%H%M
   backup_time_format: "%Y%m%d"

--- a/gitlab-project-export.py
+++ b/gitlab-project-export.py
@@ -6,7 +6,7 @@ import re
 import sys
 import time
 import argparse
-from datetime import date
+from datetime import datetime
 import requests
 from gitlab_export import config, gitlab
 
@@ -80,7 +80,7 @@ if __name__ == '__main__':
         if args.debug:
             print("Exporting %s" % (project))
 
-        # Download project to our destinationc
+        # Download project to our destination
         destination = c.config["backup"]["destination"]
         if c.config["backup"]["project_dirs"]:
             destination += "/" + project
@@ -97,7 +97,7 @@ if __name__ == '__main__':
             print(" Destination %s" % (destination))
 
         # Prepare actual date
-        d = date.today()
+        d = datetime.now()
         # File template from config
         file_tmpl = c.config["backup"]["backup_name"]
         # Projectname in dest_file
@@ -107,7 +107,7 @@ if __name__ == '__main__':
         )
         # Date in dest_file
         dest_file = dest_file.replace(
-            "{TIME}", d.strftime(c.config["backup"]["backup_time_format"]))
+            "{TIME}", d.strftime(c.config["backup"]["backup_time_format"].replace(" ", "_")))
 
         if args.debug:
             print(" Destination file %s" % (dest_file))


### PR DESCRIPTION
Currently only the date options (Ymd) are being supported in the {TIME} placeholder as the code uses only the date object. Extended it to support the time option (HMS) by switching to datetime object.
(Also, made a few cosmetic corrections to the config example)