### PR TITLE
Add support for `include_archived` & `exclude_projects` to the exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # gitlab-project-export
-Simple python project for exporting gitlab projects with Export Project feature in GitLab API.
+
+Simple Python project for exporting gitlab projects with Export Project feature in GitLab API.
 
 Primarily useful for remote backup of projects in GitLab.com to private storage server.
 
-## Breaking Changes 
+## Breaking Changes
+
 ### 05-2020
 
 Code was modified to work with Python3, not longer compatible with Python2.
@@ -24,7 +26,7 @@ or
 
 or clone the project and install manually:
 
-```
+```bash
 git clone https://github.com/rvojcik/gitlab-project-export
 cd gitlab-project-export/
 sudo python3 setup.py install
@@ -32,7 +34,7 @@ sudo python3 setup.py install
 
 or use it without installing to your environment (install only requirements):
 
-```
+```bash
 git clone https://github.com/rvojcik/gitlab-project-export
 cd gitlab-project-export/
 pip install -f requirements.txt
@@ -40,7 +42,7 @@ pip install -f requirements.txt
 
 ## Usage
 
-```
+```bash
 usage: gitlab-project-export.py [-h] [-c CONFIG] [-d] [-f]
 
 optional arguments:
@@ -48,8 +50,10 @@ optional arguments:
   -c CONFIG   config file
   -d          Debug mode
   -f          Force mode - overwrite backup file if exists
+  -n          Only print what would be done, without doing it
 ```
-```
+
+```bash
 usage: gitlab-project-import.py [-h] [-c CONFIG] [-f FILEPATH] [-p PROJECT_PATH] [-d]
 
 optional arguments:
@@ -59,6 +63,7 @@ optional arguments:
   -p PROJECT_PATH  Project path
   -d               Debug mode
 ```
+
 Prepare and edit your config file
 
 `mv config-example.yml config.yml`
@@ -68,9 +73,11 @@ Simply run the script with optional config parameter
 `./gitlab-project-export.py -c /path/to/config.yml`
 
 ## Configuration
+
 System uses simple yaml file as configuration.
 
 Example below
+
 ```
 gitlab:                                                   - gitlab configuration
   access:
@@ -88,23 +95,25 @@ backup:                                                   - backup configuration
   retention_period: 3                                     - purge files in the destination older than the specified value (in days)
   ```
 
-
-### Backup Usecase in cron
+### Backup use-case in cron
 
 Create cron file in `/etc/cron.d/gitlab-backup`
 
 With following content
-```
+
+```bash
 MAILTO=your_email@here.tld
 
 0 1 * * * root /path/to/cloned-repo/gitlab-project-export.py -c /etc/gitlab-export/config.yml
 
 ```
 
-### Migration Usecase
+### Migration use-case
+
 First create two config files
 
-config1.yml for exporting our project from gitlab.com
+`config1.yml` for exporting our project from gitlab.com
+
 ```
 gitlab:                                                   - gitlab configuration
   access:
@@ -121,7 +130,8 @@ backup:                                                   - backup configuration
                                                             python datetime - date.strftime()
 ```
 
-and config2.yml where we need only gitlab access part for importing projects to private gitlab instance
+and `config2.yml` where we need only gitlab access part for importing projects to private gitlab instance
+
 ```
 gitlab:                                                   - gitlab configuration
   access:
@@ -130,14 +140,16 @@ gitlab:                                                   - gitlab configuration
 ```
 
 Now it's time to export our projects
-```
+
+```bash
 ./gitlab-project-export.py -c ./config1.yml -d
 ```
+
 Your projects are now exported in `/data/export-dir`
 
-After that we use `gitlab-project-import.py` with config2.yml for importing into our pricate gitlab instance.
+After that we use `gitlab-project-import.py` with `config2.yml` for importing into our pricate gitlab instance.
 
-```
+```bash
 ./gitlab-project-import.py -c ./config2.yml -f ./gitlab-com-rvojcik-project1-20181224.tar.gz -p "rvojcik/project1"
 ./gitlab-project-import.py -c ./config2.yml -f ./gitlab-com-rvojcik-project2-20181224.tar.gz -p "rvojcik/project2"
 ```

--- a/config-example.yml
+++ b/config-example.yml
@@ -36,6 +36,12 @@ gitlab:
   # Maximum Retries
   # Number of times to retry, if the export fails
   max_tries_number: 12
+  # Whether to include archived projects
+  include_archived: False
+  # List of projects (or patterns) to exclude
+  exclude_projects:
+    - rvojcik/exclude-me
+    - rvojcik/archived/*
 
 #
 # Backup configuration

--- a/gitlab-project-export.py
+++ b/gitlab-project-export.py
@@ -40,6 +40,10 @@ if __name__ == '__main__':
         '-f', dest='force', default=False, action='store_const',
         const=True, help='Force mode - overwrite backup file if exists'
     )
+    parser.add_argument(
+        '-n', dest='noop', default=False, action='store_const',
+        const=True, help='Only print what would be done, without doing it'
+    )
 
     args = parser.parse_args()
 
@@ -54,6 +58,7 @@ if __name__ == '__main__':
     # Check additional config
     wait_between_exports = c.config['gitlab'].get('wait_between_exports', 0)
     membership = c.config['gitlab'].get('membership', True)
+    include_archived = c.config['gitlab'].get('include_archived', False)
     max_tries_number = c.config['gitlab'].get('max_tries_number', 12)
     retention_period = c.config['backup'].get('retention_period', 0)
     if not ((type(retention_period) == int or type(retention_period) == float) and (retention_period >= 0)):
@@ -69,7 +74,7 @@ if __name__ == '__main__':
     export_projects = []
 
     # Get All member projects from gitlab
-    projects = gitlab.project_list(membership=str(membership))
+    projects = gitlab.project_list(membership=str(membership), archived=str(include_archived))
     if not projects:
         print("Unable to get projects for your account", file=sys.stderr)
         sys.exit(1)
@@ -81,8 +86,20 @@ if __name__ == '__main__':
             if re.match(project_pattern, gitlabProject):
                 export_projects.append(gitlabProject)
 
+    # Remove any projects that are marked as excluded
+    for ignored_project_pattern in c.config["gitlab"]["exclude_projects"]:
+        for gitlabProject in projects:
+            if re.match(ignored_project_pattern, gitlabProject):
+                if args.debug:
+                    print("Removing project '%s' from export (exclusion: '%s'): " % (str(gitlabProject), str(ignored_project_pattern)))
+                export_projects.remove(gitlabProject)
+
     if args.debug:
         print("Projects to export: " + str(export_projects))
+
+    if args.noop:
+        print("Not running actual export because of -n/--noop flag.")
+        sys.exit(0)
 
     for project in export_projects:
         if args.debug:

--- a/gitlab-project-export.py
+++ b/gitlab-project-export.py
@@ -61,6 +61,7 @@ if __name__ == '__main__':
     include_archived = c.config['gitlab'].get('include_archived', False)
     max_tries_number = c.config['gitlab'].get('max_tries_number', 12)
     retention_period = c.config['backup'].get('retention_period', 0)
+    exclude_projects = c.config["gitlab"].get('exclude_projects', [])
     if not ((type(retention_period) == int or type(retention_period) == float) and (retention_period >= 0)):
         print("Invalid value for retention_period. ignoring")
         retention_period = 0
@@ -87,7 +88,7 @@ if __name__ == '__main__':
                 export_projects.append(gitlabProject)
 
     # Remove any projects that are marked as excluded
-    for ignored_project_pattern in c.config["gitlab"]["exclude_projects"]:
+    for ignored_project_pattern in exclude_projects:
         for gitlabProject in projects:
             if re.match(ignored_project_pattern, gitlabProject):
                 if args.debug:

--- a/gitlab_export/gitlab.py
+++ b/gitlab_export/gitlab.py
@@ -87,9 +87,9 @@ class Api:
             verify=self.ssl_verify,
             headers=self.headers)
 
-    def project_list(self, path_glob="", membership="True"):
+    def project_list(self, path_glob="", membership="True", archived="False"):
         ''' List projects based on glob path '''
-        urlpath = '/projects?simple=True&membership=%s&per_page=50' % (membership)
+        urlpath = '/projects?simple=True&membership=%s&archived=%s&per_page=50' % (membership, archived)
         page = 1
         output = []
         if not self.project_array:


### PR DESCRIPTION
I've made a few improvements to the export script:

* Added support for excluding archived projects (`include_archived=False`). Defaults to `False`.
* Added support for excluding (partial/regex based) projects (`exclude_projects`). This is useful if there are projects you do not want to export (e.g.  if they are too big)
* Added a no-op mode to only show which projects would be exported but not actually run the export. (use `-n` or `--noop` flag)
* Tweaked the Readme